### PR TITLE
Make directory arguments of ```debuguy parse``` work with or without ```...

### DIFF
--- a/lib/debuguy.js
+++ b/lib/debuguy.js
@@ -12,6 +12,10 @@ var fs = require('fs');
 var regex = /^(\s*)\/\*\sdebuguy\:\stag\((.+)\)\s*\*\//;
 var outputLine = '$1console.log(\'debuguy\', (new Date()).getTime(), $2);';
 
+var endsWith = function _endsWith(src, suffix) {
+    return src.indexOf(suffix, src.length - suffix.length) !== -1;
+};
+
 var debuguy = {
   parse: function(dir, out) {
     fs.readdir(dir, function (err, list) {
@@ -20,9 +24,9 @@ var debuguy = {
         return;
       }
 
-      if (!out) {
-        out = dir + 'output/';
-      }
+      dir = endsWith(dir, '/') ? dir : dir + '/';
+
+      out = out || dir;
 
       fs.exists(out, function (exists) {
         if (!exists) {


### PR DESCRIPTION
.../``` #16
- also set default output directory to the source directory
