### PR TITLE
fixed#77 - Fully supports ES6 (part1)

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -24,8 +24,11 @@ var options = {
       description:
         'parse all functions and auto add console log for debuguy\n' +
         '    options:\n' +
-        '    --r       Read source_dir recursively.\n' +
-        '    -c       Enable call stack graph.\n'
+        '    --r           Read source_dir recursively.\n' +
+        '    -c            Enable call stack graph.\n' +
+        '    --x-espect    Use e[X]perimental Espect engine to do autolog.\n' +
+        '                  Could give it a Espect template file path to \n' +
+        '                  specify the template.\n'
     }
   };
 
@@ -92,7 +95,8 @@ module.exports = {
             source: sourceDir,
             destination: destDir,
             callStackGraph: !!args.c,
-            recursive: !!args.r
+            recursive: !!args.r,
+            xEspect: args['x-espect']
           };
         } else {
           defaultOutput('No source directory specified');

--- a/lib/autolog.esp.js
+++ b/lib/autolog.esp.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = function(filepath, outpath) {
+  var opts = {};
+  if (outpath) {
+    var fs = require('fs');
+    opts.writer = {
+      write: function(advice) {
+        var code = advice.code;
+        fs.writeFile(outpath, code);
+      }
+    };
+  }
+  var Espect = require('espect.js');
+  var espect = new Espect(opts);
+  espect
+    .select(filepath + ' *')
+      .before(function(context) {
+        var id = context.meta.id;
+        var paths = context.meta.paths;
+        // XXX: To assign a result variable to prevent return
+        // be splited by comments, which now suffers from the incorrect loc.
+        var strpaths = paths.map(function(path) {
+          var merged = path.join('.'); return merged; });
+        var file = context.meta.file;
+        var filepath = file.replace(/\\/g,'/').replace( /.*\//, '' );
+        var loc = context.meta.loc;
+        // TODO: LOC is incorrect...
+        console.log('debuguy,' + Date.now() + ',' +
+          filepath + '#' + (id ? id : ('[' + strpaths.join(',') + ']')) +
+          '@' + loc.start.line);
+      })
+    .done()
+  .done();
+};

--- a/lib/dummy.esp.js
+++ b/lib/dummy.esp.js
@@ -1,0 +1,24 @@
+
+'use strict';
+
+module.exports = function(filepath, outpath) {
+  var opts = {};
+  if (outpath) {
+    var fs = require('fs');
+    opts.writer = {
+      write: function(advice) {
+        var code = advice.code;
+        fs.writeFile(outpath, code);
+      }
+    };
+  }
+  var Espect = require('espect.js');
+  var espect = new Espect(opts);
+  espect
+    .select(filepath + ' *')
+    .before(function() {
+      // Dummy advice only dump this comment.
+    })
+    .done()
+  .done();
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -203,6 +203,12 @@ Parser.prototype = {
    * @return {[type]}         [description]
    */
   autolog: function pr_autolog(options) {
+
+    function espectRewrite(filepath, outpath, template) {
+      var autologret = require(template);
+      autologret(filepath, outpath);
+    }
+
     function insertReturnLog(source, endLine) {
       var sourceRet;
       // Insert ending log at return statement.
@@ -245,6 +251,14 @@ Parser.prototype = {
     }
 
     this.traverse(options, function insertLog (dir, item, out) {
+      if (options.xEspect) {
+        var templatefile = __dirname + '/autolog.esp.js';
+        if ('string' === typeof options.xEspect) {
+          templatefile = options.xEspect;
+        }
+        espectRewrite(dir + item, out + item, templatefile);
+        return;
+      }
       fs.readFile(dir + item, function(err, data) {
         console.log('adding log ' + dir + item);
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "debuguy"
   ],
   "devDependencies": {
+    "espect.js": "^1.0.0",
     "gulp": "^3.8.11",
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",

--- a/test/sample/xespect_test_sample.js
+++ b/test/sample/xespect_test_sample.js
@@ -1,0 +1,16 @@
+(function() {
+  var a = function() {};
+  a.b = function() {};
+  a.b.c = function() {
+    function d() {
+      function e() {
+        setTimeout(function f() {}, 100);
+      }
+      e();
+    }
+    d();
+  };
+  a();
+  a.b();
+  a.b.c();
+})();

--- a/test/xespect_test.js
+++ b/test/xespect_test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// TODO: we need integration test framework...
+// To run this integration test, just execute it with plain nodejs:
+//
+//     node <debuguy>/test/xespect_test.js
+//
+// And if everything is fine, it would print nothing, just as other
+// UNIX programs. If there is something wrong, it would throw the error.
+var sourceName = 'xespect_test_sample.js';
+var sourceDir = __dirname + '/sample';
+var targetDir = require('os').tmpdir() + '/' + Date.now();
+var targetFile = targetDir + '/' + sourceName;
+var cliPath = __dirname + '/../cli.js';
+var cmdCompile = 'node ' + cliPath + ' autolog ' + sourceDir + ' ' +
+                  targetDir + ' -r --x-espect';
+var cmdApply = 'node ' + targetFile;
+var test = function(e, se) {
+  if (e) {
+    throw e;
+  }
+  var content = se.split('\n');
+  content.forEach(function(line) {
+    if ('' === line) {
+      return;
+    }
+    var matched = line.match(
+      /(debuguy),(\d+),([\w.]+)#([\[\]\w.]+)@(\d+)/);
+    // TODO: How to 'should' these?
+    if (!matched) {
+      throw new Error('No matched log: ' + line);
+    } else {
+      var tag = matched[1];
+      var date = matched[2];
+      var filename = matched[3];
+      var idpath = matched[4];
+      var ln = matched[5];
+      if ('debuguy' !== tag) {
+        throw new Error('No matched tag: ' + tag);
+      }
+      if(isNaN(date)) {
+        throw new Error('Invalid date: ' + date);
+      }
+      if(sourceName !== filename) {
+        throw new Error('Wrong file:' + filename);
+      }
+      if(!idpath) {
+        throw new Error('No function id or path');
+      } else {
+        switch(idpath) {
+          case '[]':
+          case '[]':
+          case '[a.b]':
+          case '[a.b.c]':
+          case 'd':
+          case 'e':
+          case 'f':
+            break;
+          default:
+            throw new Error('Unexpected function id or path: ' + idpath);
+        }
+      }
+      if (!ln) {
+        throw new Error('Invalid line number: ' + ln);
+      } else {
+        switch(ln) {
+          case '1':
+          case '2':
+          case '3':
+          case '4':
+          case '5':
+          case '6':
+          case '7':
+            break;
+          default:
+            throw new Error('Unexpected line number: ' + ln);
+        }
+      }
+    }
+  });
+};
+require('child_process').exec(cmdCompile,
+function (error) {
+  if (error) {
+    throw error;
+  } else {
+    require('child_process').exec(cmdApply, test);
+  }
+});


### PR DESCRIPTION
1. Add Acorn parser to support ES6 syntax
2. Forked the parser's walker to modify nodes on-the-fly to do static AOP
3. Add an 'integration' test. Although I think we should design or adopt some test frameworks when it grows up

Set review! @begeeben